### PR TITLE
Force replace relative paths to absolute

### DIFF
--- a/coverage/lcov/lcov.go
+++ b/coverage/lcov/lcov.go
@@ -52,7 +52,11 @@ func (r *reader) ReadFrom(src io.Reader) ([]*cover.Profile, error) {
 		switch {
 		case strings.HasPrefix(line, "SF:"):
 			profile = &cover.Profile{}
-			profile.FileName = line[3:]
+			if strings.HasPrefix(line[3:], "./") {
+				profile.FileName = strings.Replace(line[3:], "./", "/", 1)
+			} else {
+				profile.FileName = line[3:]
+			}
 			profile.Mode = "set"
 			profiles = append(profiles, profile)
 

--- a/coverage/lcov/lcov_test.go
+++ b/coverage/lcov/lcov_test.go
@@ -34,6 +34,27 @@ func TestSniff(t *testing.T) {
 	}
 }
 
+func TestRelativePathsReplacement(t *testing.T) {
+	got, err := New().Read(sampleFileWithRelativePaths)
+	if err != nil {
+		t.Errorf("Expected LCOV parsed successfully, got error %s", err)
+	}
+
+	if !reflect.DeepEqual(got, sampleProfilesWithAbsolutePaths) {
+		t.Errorf("Expected LCOV parsed file equals test fixture")
+	}
+}
+
+var sampleProfilesWithAbsolutePaths = []*cover.Profile{
+	{
+		FileName: "/drone/src/github.com/donny-dont/dogma-codegen/lib/src/codegen/function_generator.dart",
+		Mode:     "set",
+		Blocks: []cover.ProfileBlock{
+			{NumStmt: 1, StartLine: 30, EndLine: 30, Count: 1},
+		},
+	},
+}
+
 var sampleProfiles = []*cover.Profile{
 	{
 		FileName: "/drone/src/github.com/donny-dont/dogma-codegen/lib/src/codegen/function_generator.dart",
@@ -63,6 +84,12 @@ var sampleProfiles = []*cover.Profile{
 		},
 	},
 }
+
+var sampleFileWithRelativePaths = []byte(`
+SF:./drone/src/github.com/donny-dont/dogma-codegen/lib/src/codegen/function_generator.dart
+DA:30,84
+end_of_record
+`)
 
 var sampleFile = []byte(`
 SF:/drone/src/github.com/donny-dont/dogma-codegen/lib/src/codegen/function_generator.dart


### PR DESCRIPTION
to avoid problems when coverage tool generates coverage with relative paths
