### PR TITLE
Allow providing an internal CA cert to the plugin

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/url"
@@ -26,6 +28,7 @@ type params struct {
 	Threshold    float64 `json:"threshold"`
 	Include      string  `json:"include"`
 	MustIncrease bool    `json:"must_increase"`
+	CACert       string  `json:"ca_cert"`
 }
 
 var (
@@ -132,13 +135,26 @@ func main() {
 		v.Server = resolveServer(s.Link)
 	}
 
+	// Handle provided custom CA certs
+	caCertPool := x509.NewCertPool()
+	tlsConfig := &tls.Config{RootCAs: caCertPool}
 	cli := client.NewClient(v.Server)
+	if v.CACert != "" {
+		caCertPool.AppendCertsFromPEM([]byte(v.CACert))
+		tlsConfig = &tls.Config{RootCAs: caCertPool}
+		cli = client.NewClientTLS(v.Server, tlsConfig)
+	}
+
 	token, err := cli.Token(v.Token)
 	if err != nil {
 		fmt.Printf("Cannot authenticate. %s\n", err)
 		os.Exit(1)
 	}
-	cli = client.NewClientToken(v.Server, token.Access)
+	if v.CACert != "" {
+		cli = client.NewClientTokenTLS(v.Server, token.Access, tlsConfig)
+	} else {
+		cli = client.NewClientToken(v.Server, token.Access)
+	}
 
 	// check and see if the repository exists. if not, activate
 	if _, err := cli.Repo(r.FullName); err != nil {


### PR DESCRIPTION
This may not be the prettiest code ... but it worked for me.

Borrowed code submitted by @jackspirou to `drone-go` and `drone-cli` to get internal signed certs working for `drone-cli`.

This is slightly different though as we need to provide the root CA cert to the plugin.  So example `.drone.yml` would look something like:

``` yaml
publish:
  coverage:
    server: https://192.168.10.10
    token: $$AIRCOVER_TOKEN
    include: coverage/lcov/project.lcov
    when:
      branch: master
    ca_cert: |
      -----BEGIN CERTIFICATE-----
      ASDAS
      ASDASD
      -----END CERTIFICATE-----
```

Where ca_cert would be the internal root CA cert.
