### PR TITLE
Use relative paths when posting coverage

### DIFF
--- a/cmd_publish_test.go
+++ b/cmd_publish_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/drone-plugins/drone-coverage/client"
+)
+
+func createReport(names ...string) *client.Report {
+	report := &client.Report{}
+	var files []*client.File
+
+	for _, name := range names {
+		file := &client.File{
+			FileName: name,
+		}
+
+		files = append(files, file)
+	}
+
+	report.Files = files
+	return report
+}
+
+func TestPathModification(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(os.Stderr)
+
+	// test modified
+	report := createReport("a/b.go")
+	findFileReferences(report, "/a/")
+
+	fileName := report.Files[0].FileName
+	if fileName != "b.go" {
+		t.Errorf("Expected filename to be b.go not %s", fileName)
+	}
+
+	// test removed
+	report = createReport("a/b.go", "b/c.go")
+	findFileReferences(report, "/a/")
+
+	if len(report.Files) != 1 {
+		t.Errorf("Expected a file to be removed")
+	} else {
+		fileName = report.Files[0].FileName
+		if fileName != "b.go" {
+			t.Errorf("Expected filename to be b.go not %s", fileName)
+		}
+	}
+
+	// test file present
+	f, err := os.Create(".a.go")
+
+	if err != nil {
+		t.Errorf("Could not create file for test")
+	}
+	defer os.Remove(f.Name())
+
+	report = createReport(".a.go")
+	findFileReferences(report, "/a/")
+
+	if len(report.Files) != 1 {
+		t.Errorf("Expected file to be present")
+	} else {
+		fileName = report.Files[0].FileName
+		if fileName != ".a.go" {
+			t.Errorf("Expected filename to be .a.go not %s", fileName)
+		}
+	}
+}

--- a/coverage/path.go
+++ b/coverage/path.go
@@ -1,0 +1,39 @@
+package coverage
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+func PathPrefix(curr string, base string) (string, error) {
+	// Check for absolute paths first
+	if path.IsAbs(curr) {
+		if !strings.HasPrefix(curr, base) {
+			return "", fmt.Errorf("Path %s not found in %s", curr, base)
+		}
+
+		return base, nil
+	}
+
+	cBytes := []byte(curr)
+	bBytes := []byte(base)
+	count := len(bBytes)
+
+	// Search for the string
+	for i, _ := range bBytes {
+		for j, c := range cBytes {
+			a := i + j
+
+			if a == count {
+				return curr[:j], nil
+			}
+
+			if c != bBytes[a] {
+				break
+			}
+		}
+	}
+
+	return "", fmt.Errorf("Path %s not found in %s", curr, base)
+}

--- a/coverage/path_test.go
+++ b/coverage/path_test.go
@@ -1,0 +1,27 @@
+package coverage
+
+import "testing"
+
+func TestErrors(t *testing.T) {
+	_, err := PathPrefix("/d/e/f", "/a/b/c")
+	if err == nil {
+		t.Errorf("Expect error with two different abolute paths")
+	}
+
+	_, err = PathPrefix("d/e/f", "/a/b/c")
+	if err == nil {
+		t.Errorf("Expect error with a relative path not in absolute")
+	}
+}
+
+func TestPrefix(t *testing.T) {
+	abs, err := PathPrefix("/a/b/c/d", "/a/b/c/")
+	if err != nil && abs != "/a/b/c/" {
+		t.Errorf("Expect prefix from two absolute paths %s", abs)
+	}
+
+	rel, err := PathPrefix("b/c/d/e", "/a/b/c/")
+	if err != nil && rel != "b/c/" {
+		t.Errorf("Expect prefix from a relative path %s", rel)
+	}
+}


### PR DESCRIPTION
Added logic to use relative paths within the coverage plugin. Added test to make sure the logic works as expected.

Results when [tested locally](https://aircover.co/dogma-dart/dogma-source-analyzer/71) by running plugin directly.

@bradrydzewski if you could give this a look that'd be great. Its currently testing ever file path to make sure they are in the path so bad values don't appear. Not sure if that's what you want.