### PR TITLE
fallback to token provided in yaml

### DIFF
--- a/cmd_publish.go
+++ b/cmd_publish.go
@@ -107,7 +107,7 @@ var PublishCmd = cli.Command{
 		cli.StringFlag{
 			Name:   "token",
 			Usage:  "github token",
-			EnvVar: "GITHUB_TOKEN",
+			EnvVar: "PLUGIN_TOKEN,GITHUB_TOKEN",
 		},
 		cli.StringFlag{
 			Name:  "env-file",


### PR DESCRIPTION
# Context

This PR fixes reading the token from the `token:` key in the YAML file. Right now, we are only reading the token from Drone's secret variables