### PR TITLE
coverage.FromFile leaks Filedescriptors.

### DIFF
--- a/cmd_gocov.go
+++ b/cmd_gocov.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/drone-plugins/drone-coverage/coverage/gocov"
+	"github.com/param108/drone-coverage/coverage/gocov"
 	"github.com/mattn/go-zglob"
 	"github.com/urfave/cli"
 	"golang.org/x/tools/cover"

--- a/cmd_lcov.go
+++ b/cmd_lcov.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/drone-plugins/drone-coverage/coverage/lcov"
+	"github.com/param108/drone-coverage/coverage/lcov"
 	"github.com/mattn/go-zglob"
 	"github.com/urfave/cli"
 	"golang.org/x/tools/cover"

--- a/cmd_publish.go
+++ b/cmd_publish.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/drone-plugins/drone-coverage/client"
-	"github.com/drone-plugins/drone-coverage/coverage"
+	"github.com/param108/drone-coverage/client"
+	"github.com/param108/drone-coverage/coverage"
 	"github.com/joho/godotenv"
 	"github.com/mattn/go-zglob"
 	"github.com/urfave/cli"

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -71,6 +71,7 @@ func FromFile(path string) (bool, Reader) {
 	if err != nil {
 		return false, nil
 	}
+	defer f.Close()
 	r := io.LimitReader(f, sniffLen)
 	b, err := ioutil.ReadAll(r)
 	if err != nil {

--- a/coverage/gocov/gocov.go
+++ b/coverage/gocov/gocov.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/drone-plugins/drone-coverage/coverage"
+	"github.com/param108/drone-coverage/coverage"
 	"golang.org/x/tools/cover"
 )
 

--- a/coverage/lcov/lcov.go
+++ b/coverage/lcov/lcov.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/drone-plugins/drone-coverage/coverage"
+	"github.com/param108/drone-coverage/coverage"
 	"golang.org/x/tools/cover"
 )
 


### PR DESCRIPTION
Issue:
coverage.FromFile opens files to retrieve the first 512 bytes and forgets to close them. 
For large repositories this can break the build as we hit the file-descriptor limit.

Fix:
Added a deferred close to close the file-descriptor.