### PR TITLE
coverage.FromFile leaks Filedescriptors.

### DIFF
--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -71,6 +71,7 @@ func FromFile(path string) (bool, Reader) {
 	if err != nil {
 		return false, nil
 	}
+	defer f.Close()
 	r := io.LimitReader(f, sniffLen)
 	b, err := ioutil.ReadAll(r)
 	if err != nil {


### PR DESCRIPTION
Issue:
coverage.FromFile leaks Filedescriptors. With bigger repos this can cause a failure due to too many open files.

Fix:
Added a deferred close to the files opened.